### PR TITLE
Change the CI so it tests compiler-master on merge

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,5 +1,5 @@
-name: Github
-on: [push, pull_request]
+name: Github PR
+on: [pull_request]
 
 jobs:
   test_mac:
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [macOS-latest]
         # LDC testing is disabled for the time being due to random failures
-        dc: [dmd-2.090.0, dmd-master]
+        dc: [dmd-2.090.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -36,7 +36,66 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        dc: [dmd-2.090.0, ldc-1.19.0, dmd-master, ldc-master]
+        dc: [dmd-2.090.0, ldc-1.19.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Prepare compiler
+      uses: mihails-strasuns/setup-dlang@v0.5.0
+      with:
+        compiler: ${{ matrix.dc }}
+        gh_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build & test Agora
+      run: |
+        ./ci/ci_linux_setup.sh
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get update
+        sudo apt-get install libsqlite3-dev
+        sudo apt-get install libsodium-dev
+        sudo apt-get install g++-9
+        ./ci/run.sh
+
+name: Github Master
+on: [push]
+
+jobs:
+  test_mac:
+    name: MacOS
+    strategy:
+      matrix:
+        os: [macOS-latest]
+        # LDC testing is disabled for the time being due to random failures
+        dc: [dmd-master]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Prepare compiler
+      uses: mihails-strasuns/setup-dlang@v0.5.0
+      with:
+          compiler: ${{ matrix.dc }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Dub & Sqlite3
+      run: |
+        brew install pkg-config
+        brew install sqlite3
+    - name: Build & test agora
+      run: |
+        ./ci/ci_osx_setup.sh
+        export PATH="${PATH-}:$HOME/bin/"
+        export LIBRARY_PATH="${LD_LIBRARY_PATH-}:/usr/local/lib/"
+        export PKG_CONFIG_PATH="/usr/local/opt/sqlite/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig/"
+        ./ci/run.sh
+
+  linux_build:
+    name: Linux
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        dc: [dmd-master, ldc-master]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This reduces the flakiness caused by compiler-master
changes. If these failed, they would ordinarly
cause other runners to fail, which we do not want.